### PR TITLE
fix: install package to make radar CLI available

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,7 +34,7 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -e .
 
       - name: Download latest catalog artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem
The workflow ran `pip install -r requirements.txt` which only installs dependencies, but never installs the `oss-radar` package itself. The `radar` CLI entry point (defined in `pyproject.toml` as `radar = "radar.cli:main"`) was never created, causing every hourly run to fail with `radar: command not found` (exit code 127).

## Fix
Changed to `pip install -e .` which installs the package (creating the `radar` CLI entry point) along with all its dependencies.